### PR TITLE
Support more queries without and/or

### DIFF
--- a/src/main/java/edu/ucsd/xmlqueryprocessor/engine/Engine.java
+++ b/src/main/java/edu/ucsd/xmlqueryprocessor/engine/Engine.java
@@ -17,6 +17,7 @@ public class Engine {
     private String[] ruleNames;
     private boolean processTagName = false;
     private String pathFilterPrefix = null;
+    private boolean inequalityFlag = false;
 
     public Engine(String fileDirectory, String outputFileDirectory) {
         reset();
@@ -29,6 +30,7 @@ public class Engine {
         ruleNames = null;
         processTagName = false;
         pathFilterPrefix = null;
+        inequalityFlag = false;
     }
 
     public void process(String query, String fileName) {
@@ -216,7 +218,7 @@ public class Engine {
         String target = ((ParseTree) children.get("stringConstant")).getText();
         target = target.substring(1, target.length() - 1);
         System.out.println("\tTarget: " + target);
-        boolean inequalityFlag = pathFilterPrefix != null && pathFilterPrefix.startsWith("not");
+        inequalityFlag = pathFilterPrefix != null && pathFilterPrefix.startsWith("not");
         System.out.println("\tInequalityFlag: " + inequalityFlag);
         System.out.println("left: " + left);
 

--- a/src/main/java/edu/ucsd/xmlqueryprocessor/parser/XMLParser.java
+++ b/src/main/java/edu/ucsd/xmlqueryprocessor/parser/XMLParser.java
@@ -3,6 +3,7 @@ package edu.ucsd.xmlqueryprocessor.parser;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -18,14 +19,6 @@ import java.util.List;
 import java.util.Queue;
 
 public class XMLParser {
-
-//    public static void main(String[] args) {
-//        Document document = XMLParser.parseXML("/Users/keranwang/Desktop/Winter 24/CSE 232B/project/xquery-processor/output/result2.xml");
-////        traverseBFS(document);
-//        assert document != null;
-//        Document res = processEquality(document, "SPEAKER", "CAESAR");
-//        dumpDocument(res, "/Users/keranwang/Desktop/Winter 24/CSE 232B/project/xquery-processor/output/result2_where.xml");
-//    }
 
     public static void traverseBFS(Document document) {
         if (document == null) {
@@ -98,16 +91,54 @@ public class XMLParser {
                 String tagName = node.getNodeName();
 
                 List<String> nodeNameList = new ArrayList<>();
-                for (Node speaker : getByNodeNameHelper(node, left)) {
-                    nodeNameList.add(speaker.getTextContent());
+                for (Node n : getByNodeNameHelper(node, left)) {
+                    nodeNameList.add(n.getTextContent());
                 }
 
                 if (nodeNameList.contains(target) ^ inequalityFlag) {
                     results.add(node);
                 }
-
             }
             return convertResultsToDOM(results);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+
+    private static boolean nodeExistsDFS(Node root, String targetNodeName) {
+        NodeList childNodes = root.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (node.getNodeName().equals(targetNodeName)) {
+                return true;
+            }
+            if (nodeExistsDFS(node, targetNodeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    public static Document checkIfChildNodeExists(Document document, String targetNodeName) {
+        System.out.println("Checking if child node exists: " + targetNodeName);
+
+        try {
+            List<Node> results = new ArrayList<>();
+            Node root = document.getDocumentElement();
+            for (int i = 0; i < root.getChildNodes().getLength(); i++) {
+                Node node = root.getChildNodes().item(i);
+                if (node.getNodeName().equals(targetNodeName)) {
+                    results.add(node);
+                }
+                if (nodeExistsDFS(node, targetNodeName)) {
+                    results.add(node);
+                }
+            }
+            return convertResultsToDOM(results);
+
         } catch (Exception e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
Now the application supports the following queries:

- Find all acts that contain scene(s): `doc("j_caesar.xml")//ACT[.//SCENE]`
- Find all acts that contain subhead(s) which should be none: `doc("j_caesar.xml")//SPEECH[.//SUBHEAD]`
- `@` symbol: `doc("j_caesar.xml")//ACT[.//@SPEAKER = "CAESAR"]`
- `@` symbol with not: `doc("j_caesar.xml")//ACT[not .//@SPEAKER = "CAESAR"]`
- `*` symbol for selecting all: `doc("j_caesar.xml")//PERSONA[*]`
- Find all places where the title exists as a tag: `doc("j_caesar.xml")//TITLE/text()`
- TITLE1 does not exist, the result should be none: `doc("j_caesar.xml")//TITLE1/text()`
